### PR TITLE
Refactored `UIInfo` component

### DIFF
--- a/common/ui/components/info/UIInfo.cpp
+++ b/common/ui/components/info/UIInfo.cpp
@@ -41,7 +41,7 @@ namespace sLink::ui::component
                     color = s_ColorFail;
                     prefix = "[ERR] ";
                     break;
-                case Info::Type::INFO:
+                case Info::Type::GENERAL:
                     color = s_ColorInfo;
                     prefix = "[INFO] ";
                     break;
@@ -57,8 +57,18 @@ namespace sLink::ui::component
         ImGui::End();
     }
 
-    void UIInfo::addInfo(const Info &info)
+    void UIInfo::addSuccessInfo(std::string_view content)
     {
-        m_Infos.push_back(info);
+        m_Infos.emplace_back(content.data(), Info::Type::SUCCESS);
+    }
+
+    void UIInfo::addFailInfo(std::string_view content)
+    {
+        m_Infos.emplace_back(content.data(), Info::Type::FAIL);
+    }
+
+    void UIInfo::addGeneralInfo(std::string_view content)
+    {
+        m_Infos.emplace_back(content.data(), Info::Type::GENERAL);
     }
 }

--- a/common/ui/components/info/UIInfo.h
+++ b/common/ui/components/info/UIInfo.h
@@ -26,7 +26,7 @@ namespace sLink::ui::component
             {
                 SUCCESS,
                 FAIL,
-                INFO
+                GENERAL
             };
 
             std::string m_Content;
@@ -36,7 +36,11 @@ namespace sLink::ui::component
 
         void render() override;
 
-        void addInfo(const Info& info);
+        void addSuccessInfo(std::string_view content);
+
+        void addFailInfo(std::string_view content);
+
+        void addGeneralInfo(std::string_view content);
 
     private:
         std::vector<Info> m_Infos;


### PR DESCRIPTION
: renamed `INFO` type to `GENERAL` and split `addInfo` method into `addSuccessInfo`, `addFailInfo`, and `addGeneralInfo`